### PR TITLE
Add submit button when JS disabled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,9 @@ fn index(_: &mut Request) -> IronResult<Response> {
                         option value="week" "Week"
                         option value="month" "Month"
                     }
+                    br
+                    input#submit-button type="submit" /
+                    script "document.getElementById('submit-button').style.display = 'none'"
                 }
                 {"File size limit is " (MAX_MB) "MB"}
             }


### PR DESCRIPTION
So that Komf becomes usable with lynx and other console browsers. Firefox adds a submit button when JS disabled, but that's only Firefox.

Not tested, but it's pretty simple, I hope I am not that stupid to make any mistakes here...