### PR TITLE
State that Komf requires nightly rust in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Komf is a pomf-like file hosting!
 
-No external dependencies.
+No external dependencies. Requires rust nightly.
 
 # Usage
 


### PR DESCRIPTION
It's extremely non-obvious.

(On a side note, you could at least bump the bugfix version when introducing breaking API changes...)